### PR TITLE
Add new jobs. Adjust styles on join page

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -717,11 +717,11 @@ p.news-description{
 .read-more-button{
   background-color: rgba(27, 138, 207, 0.233);
   padding: 0.5rem 0.7rem;
+  display: inline-block;
 }
 
 .read-more-button:hover{
   background-color: rgba(27, 138, 207, 0.322);
-  padding: 0.6rem 0.9rem;
 }
 .read-more a{
   text-decoration:none;
@@ -741,7 +741,6 @@ p.news-description{
 
 .more-news-items .read-more-button:hover{
   background-color: rgba(27, 138, 207, 0.363);
-  padding: 1.1rem 1.3rem;
 }
 
 .stay-in-touch{
@@ -921,6 +920,12 @@ input[type=text]{
 .jobs .active:before {
   content: "COLLAPSE";
 }
+.jobs .accordion {
+  margin-bottom: 1rem;
+}
+.jobs .read-more-button {
+  margin-bottom: 1rem;
+}
 
 .active:before {
   content: "LESS";
@@ -957,6 +962,9 @@ input[type=text]{
   font-weight: 200;
 font-size:  2rem;
 color: #1B8BCF;
+}
+.jobs h5 {
+  margin-top: 2rem;
 }
 .bio{
   padding: 2rem 0rem;
@@ -1035,9 +1043,8 @@ width: auto;
   text-align:center;
   justify-content: center;
   align-items: left;
-  padding-left: 10%;
-  padding-right: 10%;
-
+  max-width: 45rem;
+  margin: 0 auto;
 }
 
 .join-us h3{
@@ -1049,12 +1056,20 @@ width: auto;
   font-family: 'Roboto', sans-serif;
   /*border-bottom: 5px solid #1B8BCF;*/
 }
+.join-us h4 {
+  margin: 2rem 0 1rem;
+}
 .join-us h5{
   font-weight: 300;
   color:#1B8BCF;
   font-family: 'Roboto', sans-serif;
+  text-align: left;
   /*border-bottom: 5px solid #1B8BCF;*/
 }
+.join-us h6{
+  text-align: left;
+}
+
 .join-us p{
   font-weight: 200;
   padding-bottom: 4rem;
@@ -1075,10 +1090,14 @@ color:rgb(7, 50, 77);
 background-color:rgba(27, 138, 207, 0.144);
 }
 
+.join-us.description {
+  text-align: left;
+}
+
 p#join-sub-heading {
   font-weight: 200;
   font-size: 1.2rem;
-  padding-bottom: 2rem;
+  padding-bottom: 1rem;
 }
 #reach-us{
   background-color: rgba(27, 138, 207, 0.089);
@@ -1204,6 +1223,12 @@ color: #1B8BCF;
 .color-bg{
   background-color: rgba(27, 138, 207, 0.089);
   margin-bottom: 2rem;
+}
+a.anchor {
+  display: block;
+  position: relative;
+  top: -96px;
+  visibility: hidden;
 }
 @media screen and (min-width: 1201px) and (max-width: 1450px){
 .thumbnail{

--- a/docs/join.html
+++ b/docs/join.html
@@ -105,14 +105,14 @@
 
     <h4>Our team</h4>
 
-    <p>The State of New Jersey Office of Innovation is looking for diverse and experienced team members to deploy world-class innovative and digital services that solve pressing public interest challenges for the people of New Jersey. We use data-driven, agile, human-centered and equitable design practices to deliver innovative solutions involving tech, talent, process, and policy with the support of Governor Murphy and his Administration, the Chief Innovation Officer Beth Simone Noveck, and other senior leadership.</p>
+    <p>The State of New Jersey Office of Innovation is looking for diverse and experienced team members to deploy world-class innovative and digital services that solve pressing public interest challenges for the people of New Jersey. We use data-driven, agile, and human-centered and equitable design practices to deliver innovative solutions involving tech, talent, process, and policy with the support of Governor Murphy and his Administration, the Chief Innovation Officer Beth Simone Noveck, and other senior leadership.</p>
     <p>Our team operates as a startup within government, and our team members wear many hats, contributing to both the execution of core projects and the evolution of the Office of Innovation. We kickstart new initiatives and assist teammates and partners when urgent challenges arise. We use data and modern research, design, and development methods to inform our decision making, and we collaborate with stakeholders within and outside of government to understand and solve challenges.</p>
     <p>We’re currently hiring for the following positions: </p>
     <ul>
-      <li><a href="#designer">Full-stack Product Designer</a></li>
+      <li><a href="#designer">Full-Stack Product Designer</a></li>
       <li><a href="#full-stack-engineer">Full-Stack / Site Reliability Engineer</a></li>
       <li><a href="#front-end-engineer">Front-End Engineer</a></li>
-      <li><a href="#business-director">Business Experience Director</a></li>
+      <li><a href="#business-lead">Business Experience Lead</a></li>
     </ul>
     <p>Excited to join us, but don’t see an open role for you? <a href="/you.html">Submit your profile</a> and we’ll be in touch as new opportunities arise. Expertise we seek includes: </p>
     <ul>
@@ -131,7 +131,7 @@
     <div class="jobs bio">
       <div class="jobs">
         <a class="anchor" id="designer"></a>
-        <h5>Full-stack Product Designer</h5>
+        <h5>Full-Stack Product Designer</h5>
         <div>
           <p>We are seeking a nimble product designer with at least 5 years of experience who is ready to roll up sleeves, both leading and diving into all parts of the design process. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy. Given the pandemic, we’re looking for self-starters who are skilled at driving projects forward while communicating and collaborating closely with the team at a distance. </p>
           <button class="accordion"><i class="material-icons down"></i></button>
@@ -151,7 +151,7 @@
               <li>Drive user adoption and engagement </li>
               <li>Take part in office-wide initiatives, such as stand-ups, to enable collaboration and support across projects </li>
             </ul>
-            <h6>Preferred Technical Experience, Skills and Abilities</h6>
+            <h6>Preferred Technical Experience, Skills, and Abilities</h6>
             <p>Applicants will be assessed based on an ability to excel at one or more product design disciplines: user experience design, user interface design, visual design, and content design.  </p>
             <p>We are seeking individuals with the following experience, skills, and abilities: </p>
             <ul>
@@ -185,7 +185,7 @@
             <p>As a part of the team, you will:</p>
             <ul>
               <li>Deliver solutions that meet the needs of diverse users across New Jersey</li>
-              <li>Operate as a solution architect, taking problems that may be poorly specified and finding the best software solutions, including evaluating custom developed vs. SAAS options</li>
+              <li>Operate as a solution architect, taking problems that may be poorly specified and finding the best software solutions, including evaluating custom-developed vs. SAAS options</li>
               <li>Own features end-to-end, from planning to structuring data models to designing and building front-end interfaces</li>
               <li>Apply leading industry development practices to solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
               <li>Lead a team of engineers and/or the engineering process</li>
@@ -193,21 +193,21 @@
               <li>Deliver public-facing products or features on public-facing products with a large number of users (i.e. 100,000+)</li>
               <li>Deliver tools or products with high uptime or availability requirements (i.e. SLAs of 99.9%+)</li>
               <li>Work closely with product managers, designers, experts, leadership, and diverse stakeholders to translate findings and designs into product</li>
-              <li>Iteratively release new product that can be tested with users</li>
+              <li>Iteratively release new products that can be tested with users</li>
               <li>Coordinate development activities (including the establishment of development processes) and make technical decisions that reflect the ideal solution and practical realities</li>
               <li>Build and maintain the underlying technical architecture and processes -- including a cloud environment as well as continuous integration, automated testing, and source control processes -- that will enable the team’s success across initiatives</li>
               <li>Develop technical documentation that can support the completion of state requirements</li>
               <li>Provide counsel on technical matters in plain English to our team and stakeholders</li>
               <li>Solve challenges using a wide toolkit that includes writing code, building the technical capacity of the team and State, translating user needs into technical decisions, mapping out technical options and architecture, and coaching and presenting to colleagues</li>
-              <li>Coordinate and work with in-house department and agency technical teams, including those who support legacy systems, to execute on development projects and ensure that they are setup to succeed</li>
+              <li>Coordinate and work with in-house department and agency technical teams, including those who support legacy systems, to execute on development projects and ensure that they are set up to succeed</li>
               <li>Take part in office-wide initiatives, such as stand-ups, to enable collaboration and support across projects </li>
             </ul>
-            <h6>Preferred Technical Experience, Skills and Abilities</h6>
+            <h6>Preferred Technical Experience, Skills, and Abilities</h6>
             <p>Applicants will be assessed based on an ability to excel at one or more software engineering disciplines: front-end engineering, back-end engineering, infrastructure engineering.</p>
             <p>We are seeking individuals with the following experience, skills, and abilities: </p>
             <ul>
               <li>Working at all levels of the stack </li>
-              <li>Ability to engage with technologies such as: modern JavaScript (strong) in a “Jamstack” architecture, React, Next.js, Cascading Style Sheets (CSS), Hyper Text Markup Language (HTML), JavaScript libraries, linting, and best practices, Google Cloud Platform (GCP), “NoSQL” document store persistence, and Git/GitHub version control.</li>
+              <li>Ability to engage with technologies such as: modern JavaScript (strong) in a “Jamstack” architecture, React, Next.js, Cascading Style Sheets (CSS), Hypertext Markup Language (HTML), JavaScript libraries, linting, and best practices, Google Cloud Platform (GCP), “NoSQL” document store persistence, and Git/GitHub version control.</li>
               <li>Building and applying reusable front-end design patterns to reduce future development overhead</li>
               <li>Incorporating global web design assets</li>
               <li>Translating static mockups and images into working prototypes</li>
@@ -243,14 +243,14 @@
             <p>As a part of the team, you will:</p>
             <ul>
               <li>Deliver solutions that meet the needs of diverse users across New Jersey</li>
-              <li>Take problems that may be poorly specified and find the best software solutions, including evaluating custom developed vs. SAAS options</li>
+              <li>Take problems that may be poorly specified and find the best software solutions, including evaluating custom-developed vs. SAAS options</li>
               <li>Own features end-to-end, from planning to designing and building front-end interfaces</li>
               <li>Experience applying leading industry development practices to solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
               <li>Deliver projects with complex requirements, multiple stakeholders with disparate views, or high levels of bureaucracy</li>
               <li>Deliver public-facing products or features on public-facing products with a large number of users (i.e. 100,000+)</li>
               <li>Deliver tools or products with high uptime or availability requirements (i.e. SLAs of 99.9%+)</li>
               <li>Work closely with product managers, designers, experts, leadership, and diverse stakeholders to translate findings and designs into product</li>
-              <li>Iteratively release new product that can be tested with users</li>
+              <li>Iteratively release new products that can be tested with users</li>
               <li>Coordinate development activities (including the establishment of development processes) and make technical decisions that reflect the ideal solution and practical realities</li>
               <li>Build and maintain the underlying technical architecture and processes -- including a cloud environment as well as continuous integration, automated testing, and source control processes -- that will enable the team’s success across initiatives</li>
               <li>Develop technical documentation that can support the completion of state requirements</li>
@@ -259,11 +259,11 @@
               <li>Coordinate and work with in-house department and agency technical teams, including those who support legacy systems, to execute on development projects</li>
               <li>Take part in office-wide initiatives, such as stand-ups, to enable collaboration and support across projects </li>
             </ul>
-            <h6>Preferred Experience, Skills and Abilities</h6>
+            <h6>Preferred Technical Experience, Skills, and Abilities</h6>
             <p>Applicants will be assessed based on an ability to excel as a front-end engineer.</p>
             <p>We are seeking individuals with the following experience, skills, and abilities: </p>
             <ul>
-              <li>Ability to engage with technologies such as: modern JavaScript (strong) in a “Jamstack” architecture, React, Next.js, Cascading Style Sheets (CSS), Hyper Text Markup Language (HTML), JavaScript libraries, linting, and Git/GitHub version control.</li>
+              <li>Ability to engage with technologies such as: modern JavaScript (strong) in a “Jamstack” architecture, React, Next.js, Cascading Style Sheets (CSS), Hypertext Markup Language (HTML), JavaScript libraries, linting, and Git/GitHub version control.</li>
               <li>Building and applying reusable front-end design patterns to reduce future development overhead</li>
               <li>Incorporating global web design assets</li>
               <li>Translating static mockups and images into working prototypes</li>
@@ -284,10 +284,10 @@
 
     <div class="jobs bio">
       <div class="jobs">
-        <a class="anchor" id="business-director"></a>
-        <h5>Business Experience Director</h5>
+        <a class="anchor" id="business-lead"></a>
+        <h5>Business Experience Lead</h5>
         <div>
-          <p>The Business Experience Director will be responsible for reimagining and driving the experience of businesses when interacting with the State. You’ll do this by driving the production of constantly-evolving content, getting user feedback regularly through standardized user testing, engaging with a diverse audience, and acting as stakeholder for new technologies and interfaces through the Business First Stop initiative. The role will thus include elements of content creation, marketing research, user testing, experience design, communications management, and product management. You’ll be empowered outside of the standard agency structure, avoiding the trap of “shipping an org chart” and instead delivering a cohesive experience. Given the pandemic, we’re looking for self-starters who are skilled at driving projects forward while communicating and collaborating closely with the team at a distance. </p>
+          <p>We are seeking a talented and experienced professional that will be responsible for transforming the experience of businesses interacting with the State. You’ll do this by driving the production of constantly-evolving content, getting user feedback regularly through standardized user testing, engaging with a diverse audience, and acting as a stakeholder for new technologies and interfaces through the <a href="https://innovation.nj.gov/projects.html#bfs">Business First Stop</a> initiative. The role will include elements of content creation, marketing research, user testing, experience design, communications management, and product management. You’ll be empowered outside of the standard agency structure, avoiding the trap of “shipping an org chart” and instead delivering a cohesive experience. Given the pandemic, we’re looking for self-starters who are skilled at driving projects forward while communicating and collaborating closely with the team at a distance. </p>
           <button class="accordion"><i class="material-icons down"></i></button>
           <div class="panel">
             <p>As a part of the team, you will:</p>
@@ -311,7 +311,7 @@
               </ul>
               <li>Take part in office-wide initiatives, such as stand-ups, to enable collaboration and support across projects </li>
             </ul>
-            <p>Preferred Technical Experience, Skills and Abilities</p>
+            <p>Preferred Technical Experience, Skills, and Abilities</p>
             <p>Applicants will be assessed based on an ability to excel at content strategy, editing, and product management. </p>
             <p>We are seeking individuals with the following experience, skills, and abilities: </p>
             <ul>
@@ -361,7 +361,7 @@
       <li>Be committed and know how to develop metrics and experiments to test what works</li>
     </ul>
 
-    <h5>Since our creation, we have engaged on a wide variety of issues, including:</h5>
+    <h5>Since our creation, we have engaged in a wide variety of issues, including:</h5>
     <ul>
       <li>Responding to emerging and urgent needs, such as the COVID-19 pandemic, by deploying modern digital services and expanding the use and availability of data</li>
       <li>Improving the delivery of benefits and services, including Unemployment Insurance and SNAP</li>

--- a/docs/join.html
+++ b/docs/join.html
@@ -93,132 +93,259 @@
       </div>
     <div class="join-us" style="background-color:#ffffff">
       <h3>Join Us</h3>
-     <p id="join-sub-heading">
-    Interested in improving the lives of New Jerseyans by designing and delivering modern policies and services?<br><br>
-    Share your contact information so we can be in touch when opportunities arise in the future.<br>
-    <div class="more-news-items">
-       <a href="you.html"> <span class="read-more-button">Tell Us About Yourself</span></a>
-    </div>
-  </p>
-
+      <p id="join-sub-heading">Interested in improving the lives of New Jerseyans by designing and delivering modern policies and services?</p>
+      <div class="more-news-items">
+        <a href="#roles"><span class="read-more-button">See open roles</span></a>
+      </div>
     </div>
 
     <div class="join-us description">
 
-    <h4>About Us</h4>
-    <p>
-      The New Jersey State Office of Innovation was created by Governor Phil Murphy in August, 2018 with the appointment of Dr. Beth Simone Noveck as the State's first-ever Chief Innovation Officer.
-   </p>
-   <p>The Office of Innovation was founded with the mandate to improve the lives of New Jerseyans by designing and deploying more effective and efficient government services. We work in partnership with the Governor’s Office and State agencies to create innovative policies and technologies that address complex public problems by working differently: we apply data science and public engagement to understand problems, and  we use the latest digital technologies combined with strategic policies to develop solutions that improve services while also reducing costs for the State and the taxpaying public.
-  </p>
-  <p>
-    Our team is made up of dedicated and energetic individuals with experience in government, business, civic tech, policy, and engagement. We are passionate about transforming the way government operates, and we support State agencies in innovating and improving the lives of all New Jerseyans. We partner with teams throughout the state to design and deploy world-class, innovative, and inclusive policies and digital services that solve pressing public interest challenges. With the support of the Governor, the Chief Innovation Officer, and other senior leadership, the team uses modern practices to deliver solutions that positively impact the lives of New Jerseyans and the state’s businesses and institutions.
-  </p>
-  <p> Since our creation, we have engaged on a wide variety of issues, including:
-  </p>
-  <ul>
-  <li>Responding to emerging and urgent needs, such as the COVID-19 pandemic, by deploying modern digital services and expanding the use and availability of data</li>
-  <li>Creating tools to enable the public to participate in open policy making</li>
-  <li>Making modern career services and digital tools available to support job seekers in identifying, preparing for, and obtaining family-sustaining jobs</li>
-  <li>Improving the way entrepreneurs and business owners start, operate, and grow their businesses in the state</li>
-  <li>Exploring policy innovations on issue areas such as economic development, technology governance, open data, open governance, autonomous vehicles, broadband, workforce development and more</li>
-  </ul>
+    <h4>Our team</h4>
 
-  <p>You can learn more about some of our initiatives on the <a href="https://innovation.nj.gov/projects.html">project page.</a></p>
-  <p>Our team operates as a startup within government, and our team members wear many hats, contributing to both the execution of core projects and the evolution of the Office of Innovation. We kickstart new initiatives and assist teammates and partners when urgent challenges arise. We use data and modern research methods to inform our decision making, and we collaborate with stakeholders within and outside of government to understand and solve challenges.</p>
-  <p>We believe this mission can only be fulfilled with a diverse and inclusive team, environment, and approach. Are you interested in joining us?</p>
+    <p>The State of New Jersey Office of Innovation is looking for new team members to deploy world-class innovative and digital services that solve pressing public interest challenges for the people of New Jersey. We use data-driven, agile, and human-centered design practices to deliver innovative solutions involving tech, talent, process, and policy with the support of the Governor and his Administration, the Chief Innovation Officer, and other senior leadership.</p>
+    <p>Our team operates as a startup within government, and our team members wear many hats, contributing to both the execution of core projects and the evolution of the Office of Innovation. We kickstart new initiatives and assist teammates and partners when urgent challenges arise. We use data and modern research, design, and development methods to inform our decision making, and we collaborate with stakeholders within and outside of government to understand and solve challenges.</p>
 
-    <h3>Sample Profiles</h3>
+    <a class="anchor" id="roles"></a>
+    <h4>Open roles</h4>
 
+    <ul>
+      <li><a href="#designer">Product Designer (Full-Stack UX/UI)</a></li>
+      <li><a href="#business-director">Business Experience Director</a></li>
+      <li><a href="#front-end-engineer">Front End Engineer</a></li>
+      <li><a href="#full-stack-engineer">Full-Stack / Site Reliability Engineer</a></li>
+    </ul>
 
-      <div class="jobs bio">
-          <div class="jobs bio-desc">
-          <h4>Product Design</h4>
-          <div>
-              <p>Product designers run different parts of the design process. Designers lead end-to-end research through execution of UX and UI using modern practices and tools to arrive at key insights and solutions that can be iteratively implemented by the team and tested with users. As part of the team, designers:</p>
+    <div class="jobs bio">
+      <div class="jobs">
+        <a class="anchor" id="designer"></a>
+        <h5>Product Designer (Full-Stack UX/UI)</h5>
+        <div>
+          <p>We are seeking a nimble product designer with at least 5 years of experience who is ready to roll up sleeves, both leading and diving into all parts of the design process. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy.</p>
+          <button class="accordion"><i class="material-icons down"></i></button>
+          <div class="panel">
+            <p>As a part of the team, you will:</p>
             <ul>
-              <li>Lead the end-to-end human-centered design and research process</li>
-              <li>Work with stakeholders to define the problem and create + execute a research plan</li>
-              <li>Use both human-centered and data-driven research methodologies to generate insights and key learnings and assess potential solutions</li>
-              <li>Design prototypes, such as mockups and wireframes of varying fidelity, to share with team members, stakeholders and users</li>
-              <li>Work closely with developers, teammates, and partners to bring designs to life and iteratively improve solutions</li>
+              <li>Lead end-to-end research planning and execution using modern practices and tools to arrive at key insights and solutions that can be iteratively developed by the team and tested with users</li>
+              <li>Partner closely with engineers, product managers, and other team members to translate UX/UI design into iteratively developed products that meet the needs of our users</li>
+              <li>Solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
+              <li>Create and execute research and testing plans for each phase of the project</li>
+              <li>Use both human-centered and data-driven research methodologies to generate insights and key learnings</li>
+              <li>Design mockups, wireframes, user stories, and other guides that inform the development of products and can be shared with team members and stakeholders</li>
+              <li>Develop and iterate on content that meets the needs of our users</li>
+              <li>Collaborate with stakeholders and subject matter experts to define new features and iterate existing capabilities</li>
+              <li>Serve as a coach and catalyst for leveraging modern data-driven and human-centered design practices across the team and the State in the areas of design research, interaction design, service design, visual design, and information architecture</li>
+              <li>Drive user adoption and engagement </li>
             </ul>
-            <div class="join-us-button">
-            </div>
+            <h6>Preferred Technical Experience, Skills and Abilities</h6>
+            <p>Applicants will be assessed based on an ability to excel at one or more product design disciplines: user experience design, user interface design, visual design, and content design.  </p>
+            <p>We are seeking individuals with the following experience, skills, and abilities: </p>
+            <ul>
+              <li>Leading user experience design and research to iteratively develop digital products or services within large or complex environments as part of a cross-functional team</li>
+              <li>Defining user needs and experience goals using such frameworks as personas, storyboards, scenarios, and flowcharts</li>
+              <li>Designing and specifying user interfaces and information architecture, reusing design patterns where relevant</li>
+              <li>Developing accessible content</li>
+              <li>Leveraging technologies such as Sketch, Adobe Creative Cloud, and equivalent interaction design tools; InVision, Quartz Composer, or equivalent prototyping tools; and modern CSS and HTML. </li>
+              <li>Prototyping designs at varying levels of fidelity using static mocks, click-through prototypes, basic CSS and HTML</li>
+              <li>Working closely with front-end engineers to translate wireframes and prototypes into functional working front-end code</li>
+              <li>Setting up and facilitating user research sessions to assess the usability of designs or live code</li>
+              <li>Communicating research findings, design rationale, and goals both verbally and visually</li>
+              <li>Leveraging global web design standards</li>
+            </ul>
           </div>
+          <a href="you.html" class="read-more-button">Apply now</a>
         </div>
       </div>
+    </div>
 
-      <div class="jobs bio">
-          <div class="jobs bio-desc">
-          <h4>Software Engineering</h4>
-          <div>
-              <p>Engineers and architects translate concepts into solutions for users. Engineers are involved in all aspects of understanding, assessing, and building tech solutions. As part of the team, engineers:</p>
+    <div class="jobs bio">
+      <div class="jobs">
+        <a class="anchor" id="business-director"></a>
+        <h5>Business Experience Director</h5>
+        <div>
+          <p>The Business Experience Director will be responsible for reimagining and driving the experience of businesses when interacting with the state. You’ll do this by driving the production of constantly-evolving content, similarly getting user feedback regularly through standardized user testing, and acting as stakeholder for new technologies and interfaces through the Business First Stop initiative. The role will thus include elements of content creation, marketing research, user testing, experience design, communications management and product management. You’ll be empowered by being positioned outside of the standard agency structure, avoiding the trap of “shipping an org chart” instead of a cohesive experience.</p>
+          <button class="accordion"><i class="material-icons down"></i></button>
+          <div class="panel">
+            <p>As a part of the team, you will:</p>
             <ul>
-              <li>Lead the development and delivery of modern solutions that meet the needs of users</li>
-              <li>Work with designers and the team to translate findings and designs into product</li>
+              <li>Expand Business.NJ.gov content and content delivery as “Editor-in-Chief”:</li>
+              <ul>
+                <li>Develop the ‘start your business’ experience on Business.NJ.gov</li>
+                <li>Develop and run communication with businesses to keep them informed of services, resources, new rules/regs, COVID-updates, etc.</li>
+                <li>Conduct message and content testing sessions on an ongoing basis to ensure content is useable as intended; incorporate feedback/data from website and the Business.NJ.gov chat system to inform content development</li>
+              </ul>
+              <li>Increase business community feedback loops through market research and user testing</li>
+              <ul>
+                <li>Coordinate interviews, surveys, focus groups and stakeholder engagement to bolster feedback mechanisms with small businesses and industry stakeholders and drive strategic development and prioritization of our initiatives</li>
+              </ul>
+              <li>Lead the creation of a new customer service experience for businesses</li>
+              <ul>
+                <li>Coordinate the creation of and manage a cross-departmental customer service operations team to ensure rapid response to business inquiries </li>
+                <li>Coordinate the creation of and manage a cross-departmental customer service advisory council to develop principles and guidelines that must be followed by all agencies and departments when serving businesses</li>
+                <li>Ensure knowledge gained from research and customer service delivery, including business obstacles and burdens, are informing Business.NJ.gov technology and policy decision-making</li>
+              </ul>
+            </ul>
+            <h6>Preferred Technical Experience, Skills and Abilities</h6>
+            <p>Applicants will be assessed based on an ability to excel at content strategy, editing, and product management. </p>
+            <p>We are seeking individuals with the following experience, skills, and abilities: </p>
+            <ul>
+              <li>Writing and developing technical content that is accessible and easily understood for the public</li>
+              <li>Conducting market research and audience analysis</li>
+              <li>Conducting message and content testing</li>
+              <li>Writing, managing, and distributing email and newsletter content, and managing an online newsletter distribution network</li>
+              <li>Managing editorial content and writing assignment with a number of stakeholders and content creators</li>
+              <li>Conducting user interviews and focus groups</li>
+              <li>Crafting and distributing surveys</li>
+              <li>Coordinating stakeholder engagement among multiple stakeholders and oversight departments</li>
+              <li>Establishing customer relationships and customer service standards</li>
+              <li>Incorporating customer feedback and analysis into product design</li>
+              <li>Developing user experience (UX) mockups and prototypes</li>
+              <li>Interpreting web analytics and incorporating into UX prototypes and interface designs</li>
+              <li>Product management and developing product requirements, feature requests, and interface options</li>
+              <li>Developing low-fidelity mockups</li>
+              <li>Using content management systems</li>
+              <li>Technical writing</li>
+              <li>Incorporating global web design assets</li>
+            </ul>
+          </div>
+          <a href="you.html" class="read-more-button">Apply now</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="jobs bio">
+      <div class="jobs">
+        <a class="anchor" id="front-end-engineer"></a>
+        <h5>Front End Engineer</h5>
+        <div>
+          <p>We are seeking a front end software engineer with at least 4 years of experience using modern languages and practices who can translate a concept into initial solutions for users. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy.</p>
+          <button class="accordion"><i class="material-icons down"></i></button>
+          <div class="panel">
+            <p>As a part of the team, you will:</p>
+            <ul>
+              <li>Take problems that may be poorly specified and find the best software solutions, including evaluating custom developed vs. SAAS options</li>
+              <li>Own features end-to-end, from planning to designing and building front-end interfaces</li>
+              <li>Experience applying leading industry development practices to solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
+              <li>Deliver projects with complex requirements, multiple stakeholders with disparate views or high levels of bureaucracy</li>
+              <li>Deliver public-facing products or features on public-facing products with a large number of users (i.e. 100,000+)</li>
+              <li>Deliver tools or products with high uptime or availability requirements (i.e. SLAs of 99.9%+)</li>
+              <li>Work closely with product managers, designers, experts, leadership, and key stakeholders to translate findings and designs into product</li>
               <li>Iteratively release new product that can be tested with users</li>
-              <li>Establish foundational infrastructure required for deploying solutions</li>
-              <li>Coordinate development activities (including the establishment of development processes) and make technical decisions</li>
+              <li>Coordinate development activities (including the establishment of development processes) and make technical decisions that reflect the ideal solution and practical realities</li>
+              <li>Build and maintain the underlying technical architecture and processes -- including a cloud environment as well as continuous integration, automated testing, and source control processes -- that will enable the team’s success across initiatives</li>
+              <li>Develop technical documentation that can support the completion of state requirements</li>
               <li>Provide counsel on technical matters in plain English to our team and stakeholders</li>
-              <li>Coordinate and work with in-house technical teams in agencies, including those who support legacy systems, to execute on development projects</li>
+              <li>Solve challenges using a wide toolkit that includes writing code, building the technical capacity of the team and State, translating user needs into technical decisions, mapping out technical options and architecture, and coaching and presenting to colleagues</li>
+              <li>Coordinate and work with in-house department and agency technical teams, including those who support legacy systems, to execute on development projects</li>
             </ul>
-            <div class="join-us-button">
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="jobs bio">
-          <div class="jobs bio-desc">
-          <h4>Digital Product Management</h4>
-          <div>
-              <p>Digital product and project managers lead cross-functional teams using data-driven decision making, human-centered design, agile methodologies, and modern practices. As part of the team, product managers:</p>
+            <h6>Preferred Experience, Skills and Abilities</h6>
+            <p>Applicants will be assessed based on an ability to excel as a front-end engineer.</p>
+            <p>We are seeking individuals with the following experience, skills, and abilities: </p>
             <ul>
-              <li>Lead end-to-end product and project management activities to enable the delivery of modern solutions that meet the needs of users for a key project</li>
-              <li>Establish the project environment necessary to operate as a high performing cross-functional team in partnership with stakeholders</li>
-              <li>Develop and communicate the vision, strategy, and product roadmap</li>
-              <li>Lead end-to-end agile product development, including managing state requirements</li>
-              <li>Understand the landscape of approaches and solutions to inform New Jersey’s approach</li>
-              <li>Communicate and collaborate with partners throughout the state to ensure we are enabling their long-term success</li>
-              <li>Support team members by helping them clear any challenges they may encounter</li>
-              <li>Drive open communication regarding the project with the public (e.g., blog posts)</li>
+              <li>Ability to engage with technologies such as: modern JavaScript (strong) in a “Jamstack” architecture, React, Next.js, Cascading Style Sheets (CSS), Hyper Text Markup Language (HTML), JavaScript libraries, linting, and Git/GitHub version control.</li>
+              <li>Building and applying re-usable front-end design patterns to reduce future development overhead</li>
+              <li>Incorporating global web design assets</li>
+              <li>Translating static mockups and images into working prototypes</li>
+              <li>Ensuring 508 accessibility compliance with the assistance of automated testing tools</li>
+              <li>Writing well-designed, testable, efficient code</li>
+              <li>Ensure seamless integration among front- and backend systems</li>
+              <li>Mitigating common security vulnerabilities (e.g., cross-site scripting)</li>
+              <li>Executing full lifecycle software development</li>
+              <li>Writing developer-friendly documentation (e.g., API documentation, deployment operations)</li>
+              <li>Ensuring system uptime and performance</li>
+              <li>Monitoring and notifying appropriate officials in the case of security and data breaches</li>
             </ul>
-            <div class="join-us-button">
-            </div>
           </div>
+          <a href="you.html" class="read-more-button">Apply now</a>
         </div>
       </div>
+    </div>
 
-      <div class="jobs bio">
-          <div class="jobs bio-desc">
-          <h4>Policy + Engagement</h4>
-          <div>
-              <p>Public policy and community engagement professionals design, develop, implement, and manage projects and initiatives for the Office’s portfolio of work related to policy and public consultations. They manage and support a diverse array of projects that require program and project management and coordination, policy research, and intergovernmental relations and external affairs support. As part of the team, public policy and community engagement team members:</p>
+    <div class="jobs bio">
+      <div class="jobs">
+        <a class="anchor" id="full-stack-engineer"></a>
+        <h5>Full-Stack / Site Reliability Engineer</h5>
+        <div>
+          <p>We are seeking site reliability and full-stack software engineers with at least 5 years of experience using modern languages and practices who can translate a concept into initial solutions for users. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy.</p>
+          <button class="accordion"><i class="material-icons down"></i></button>
+          <div class="panel">
+            <p>As a part of the team, you will:</p>
             <ul>
-              <li>Design, develop, and author policy memoranda, research briefs, reports and other documents related to diverse subject matters in both independent and collaborative settings</li>
-              <li>Provide project management support for Office of Innovation projects and initiatives related to public consultations, innovation skills training, open data, and open governance</li>
-              <li>Cultivate robust public participation and user engagement in public consultation programs, and identify and develop high-value strategic partnerships to amplify the promotion of engagement efforts</li>
-              <li>Research state government regulations and processes related to procurement and technology development, and assist with team/project compliance</li>
-              <li>Work collaboratively with cross-functional technology development teams to support ongoing projects and initiatives</li>
-              <li>Monitor and leverage ongoing news, articles, and research related to government and private-sector innovations</li>
+              <li>Operate as a solution architect, taking problems that may be poorly specified and finding the best software solutions, including evaluating custom developed vs. SAAS options</li>
+              <li>Own features end-to-end, from planning to structuring data models to designing and building front-end interfaces</li>
+              <li>Experience applying leading industry development practices to solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
+              <li>Lead a team of engineers and/or the engineering process</li>
+              <li>Deliver projects with complex requirements, multiple stakeholders with disparate views or high levels of bureaucracy</li>
+              <li>Deliver public-facing products or features on public-facing products with a large number of users (i.e. 100,000+)</li>
+              <li>Deliver tools or products with high uptime or availability requirements (i.e. SLAs of 99.9%+)</li>
+              <li>Work closely with product managers, designers, experts, leadership, and key stakeholders to translate findings and designs into product</li>
+              <li>Iteratively release new product that can be tested with users</li>
+              <li>Coordinate development activities (including the establishment of development processes) and make technical decisions that reflect the ideal solution and practical realities</li>
+              <li>Build and maintain the underlying technical architecture and processes -- including a cloud environment as well as continuous integration, automated testing, and source control processes -- that will enable the team’s success across initiatives</li>
+              <li>Develop technical documentation that can support the completion of state requirements</li>
+              <li>Provide counsel on technical matters in plain English to our team and stakeholders</li>
+              <li>Solve challenges using a wide toolkit that includes writing code, building the technical capacity of the team and State, translating user needs into technical decisions, mapping out technical options and architecture, and coaching and presenting to colleagues</li>
+              <li>Coordinate and work with in-house department and agency technical teams, including those who support legacy systems, to execute on development projects and ensure that they are setup to succeed</li>
             </ul>
-            <div class="join-us-button">
-            </div>
+            <h6>Preferred Technical Experience, Skills and Abilities</h6>
+            <p>Applicants will be assessed based on an ability to excel at one or more software engineering disciplines: front-end engineering, back-end engineering, infrastructure engineering.</p>
+            <p>We are seeking individuals with the following experience, skills, and abilities: </p>
+            <ul>
+              <li>Working at all levels of the stack </li>
+              <li>Ability to engage with technologies such as: modern JavaScript (strong) in a “Jamstack” architecture, React, Next.js, Cascading Style Sheets (CSS), Hyper Text Markup Language (HTML), JavaScript libraries, linting, and best practices, Google Cloud Platform (GCP), “NoSQL” document store persistence, and Git/GitHub version control.</li>
+              <li>Building and applying re-usable front-end design patterns to reduce future development overhead</li>
+              <li>Incorporating global web design assets</li>
+              <li>Translating static mockups and images into working prototypes</li>
+              <li>Ensuring 508 accessibility compliance with the assistance of automated testing tools</li>
+              <li>Writing well-designed, testable, efficient code</li>
+              <li>Writing automated feature/functional tests for application flows</li>
+              <li>Ensure seamless integration among front- and backend systems</li>
+              <li>Mitigating common security vulnerabilities (e.g., cross-site scripting)</li>
+              <li>Executing full lifecycle software development</li>
+              <li>Consuming application programming interfaces (APIs) to new and legacy internal and external systems, some of which may be undocumented</li>
+              <li>Translating application requirements into APIs, libraries/utilities, data models, and database schemas</li>
+              <li>Writing developer-friendly documentation (e.g., API documentation, deployment operations)</li>
+              <li>Improving shared libraries/utilities and practices around authentication, logging, alerting, and monitoring</li>
+              <li>Debugging and diagnosing issues in distributed systems</li>
+              <li>Designing infrastructure for supporting continuous integration, continuous deployment, and monitoring</li>
+              <li>Ensuring system uptime and performance</li>
+              <li>Monitoring and notifying appropriate officials in the case of security and data breaches</li>
+            </ul>
           </div>
+          <a href="you.html" class="read-more-button">Apply now</a>
         </div>
       </div>
+    </div>
 
+    <h4>About the Office of Innovation</h4>
+    <p>Founded with the mandate to improve the lives of New Jerseyans by designing and deploying more effective and efficient government services, the Office of Innovation works in partnership with the Governor’s office, State agencies, and outside partners to create innovative policies and technologies that address complex public problems by working differently. We apply data science and public engagement to understand problems, and use the latest digital technologies combined with strategic policies to develop solutions that improve services while also reducing costs for the State and the taxpaying public. </p>
 
-    <h3>Eligibility</h3>
-    <p style="padding-bottom:4rem;">
-      You must be authorized to work in the United States. Candidates may be required to pass a background check and complete additional steps as part of the application and onboarding process. We are an equal opportunity employer. We don’t discriminate based on race, color, religion, sex, gender identity or expression, national origin, political affiliation, sexual orientation, marital status, disability, genetic information, age, membership in an employee organization, retaliation, parental status, military service, or other non-merit factors.
-      <div class="more-news-items">
-         <a href="you.html"> <span class="read-more-button">Tell Us About Yourself</span></a><br><br><br>
-      </div>
+    <h5>Principals we innovate by:</h5>
+    <ul>
+      <li>Build with New Jerseyans, putting them at the center of our work</li>
+      <li>Solve problems by breaking down silos and forming partnerships - across teams, departments, agencies, levels of government, and with external experts</li>
+      <li>Deliver accessible solutions and policies that meet the needs of real people</li>
+      <li>Succeed in a highly ambiguous environment with little definition or structure</li>
+      <li>Maintain strong domain expertise while keeping a cross-functional approach Acknowledge and overcome constraints as they arise</li>
+      <li>Collaborate with stakeholders in domains beyond technology such as legal, policy, and administrative roles</li>
+      <li>Be committed and know how to develop metrics and experiments to test what works</li>
+      <li>Enable the long-term success of our partners throughout the state</li>
+    </ul>
 
-    </p>
+    <h4>Notes</h4>
+    <p>The examples of work for this title are for illustrative purposes only. A particular position using this title may not perform all duties listed in this job description. Conversely, all duties performed on the job may not be listed. This job description is intended to convey information essential to understanding the scope, general nature and level of work performed by job holders within this job. This job description is not intended to be an exhaustive list of qualifications, skills, efforts, duties, responsibilities or working conditions associated with the position.</p>
+    <p>Your employment is voluntary and subject to termination at will, with or without cause, or with or without notice, at any time. Nothing in this job description shall be interpreted to conflict, eliminate or modify the employment-at-will status of employees.</p>
+    <p>This position is considered exempt and is excluded from minimum wage, overtime regulations, and other rights and protections afforded nonexempt workers under FLSA.</p>
+    <p>We reserve the right to amend/revise this job description as necessary to meet current and changing business needs.</p>
 
+    <h4>The New Jersey Office of Innovation is proud to be an equal opportunity employer</h4>
+    <p>We are deeply committed to the principles of equity, diversity, and inclusiveness and seek to create a pluralistic community for all.</p>
+    <p>We strongly encourage people of color, members of racial and ethnic minority groups, women, LGBTQI+ people, those with disabilities, and Veterans to apply. We are committed to building a team that is reflective of New Jersey’s incredible diversity.  </p>
+    <p>We do not discriminate against any candidate because of color, race, age, religion, sex, gender identity or expression, sexual orientation, membership in an employee organization, pregnancy, marital status, status as a parent, ancestry, national origin, disability (physical or mental), family medical history or genetic information, political affiliation, military service, retaliation, or other non-merit based factors.</p>
+
+    <h4>Eligibility</h4>
+    <p>You must be authorized to work in the United States. Candidates may be required to pass a background check and complete additional steps as part of the application and onboarding process.</p>
+    <p><br></p>
   </div>
 
   <footer class="thin-footer">

--- a/docs/join.html
+++ b/docs/join.html
@@ -94,6 +94,8 @@
     <div class="join-us" style="background-color:#ffffff">
       <h3>Join Us</h3>
       <p id="join-sub-heading">Interested in improving the lives of New Jerseyans by designing and delivering modern policies and services?</p>
+      <p id="join-sub-heading">Apply for open roles or share your profile so we can be in touch when additional opportunities arise in the future.</p>
+
       <div class="more-news-items">
         <a href="#roles"><span class="read-more-button">See open roles</span></a>
       </div>
@@ -103,45 +105,58 @@
 
     <h4>Our team</h4>
 
-    <p>The State of New Jersey Office of Innovation is looking for new team members to deploy world-class innovative and digital services that solve pressing public interest challenges for the people of New Jersey. We use data-driven, agile, and human-centered design practices to deliver innovative solutions involving tech, talent, process, and policy with the support of the Governor and his Administration, the Chief Innovation Officer, and other senior leadership.</p>
+    <p>The State of New Jersey Office of Innovation is looking for diverse and experienced team members to deploy world-class innovative and digital services that solve pressing public interest challenges for the people of New Jersey. We use data-driven, agile, human-centered and equitable design practices to deliver innovative solutions involving tech, talent, process, and policy with the support of Governor Murphy and his Administration, the Chief Innovation Officer Beth Simone Noveck, and other senior leadership.</p>
     <p>Our team operates as a startup within government, and our team members wear many hats, contributing to both the execution of core projects and the evolution of the Office of Innovation. We kickstart new initiatives and assist teammates and partners when urgent challenges arise. We use data and modern research, design, and development methods to inform our decision making, and we collaborate with stakeholders within and outside of government to understand and solve challenges.</p>
+    <p>We’re currently hiring for the following positions: </p>
+    <ul>
+      <li><a href="#designer">Full-stack Product Designer</a></li>
+      <li><a href="#full-stack-engineer">Full-Stack / Site Reliability Engineer</a></li>
+      <li><a href="#front-end-engineer">Front-End Engineer</a></li>
+      <li><a href="#business-director">Business Experience Director</a></li>
+    </ul>
+    <p>Excited to join us, but don’t see an open role for you? <a href="/you.html">Submit your profile</a> and we’ll be in touch as new opportunities arise. Expertise we seek includes: </p>
+    <ul>
+      <li>Product Management</li>
+      <li>Product Design </li>
+      <li>Engineering</li>
+      <li>Policy and Engagement</li>
+      <li>Research</li>
+      <li>Content Strategy</li>
+      <li>Data Science</li>
+    </ul>
 
     <a class="anchor" id="roles"></a>
     <h4>Open roles</h4>
 
-    <ul>
-      <li><a href="#designer">Product Designer (Full-Stack UX/UI)</a></li>
-      <li><a href="#business-director">Business Experience Director</a></li>
-      <li><a href="#front-end-engineer">Front End Engineer</a></li>
-      <li><a href="#full-stack-engineer">Full-Stack / Site Reliability Engineer</a></li>
-    </ul>
-
     <div class="jobs bio">
       <div class="jobs">
         <a class="anchor" id="designer"></a>
-        <h5>Product Designer (Full-Stack UX/UI)</h5>
+        <h5>Full-stack Product Designer</h5>
         <div>
-          <p>We are seeking a nimble product designer with at least 5 years of experience who is ready to roll up sleeves, both leading and diving into all parts of the design process. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy.</p>
+          <p>We are seeking a nimble product designer with at least 5 years of experience who is ready to roll up sleeves, both leading and diving into all parts of the design process. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy. Given the pandemic, we’re looking for self-starters who are skilled at driving projects forward while communicating and collaborating closely with the team at a distance. </p>
           <button class="accordion"><i class="material-icons down"></i></button>
           <div class="panel">
             <p>As a part of the team, you will:</p>
             <ul>
+              <li>Deliver solutions that meet the needs of diverse users across New Jersey</li>
               <li>Lead end-to-end research planning and execution using modern practices and tools to arrive at key insights and solutions that can be iteratively developed by the team and tested with users</li>
               <li>Partner closely with engineers, product managers, and other team members to translate UX/UI design into iteratively developed products that meet the needs of our users</li>
               <li>Solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
               <li>Create and execute research and testing plans for each phase of the project</li>
-              <li>Use both human-centered and data-driven research methodologies to generate insights and key learnings</li>
+              <li>Use both equitable human-centered and data-driven research methodologies to generate insights and key learnings</li>
               <li>Design mockups, wireframes, user stories, and other guides that inform the development of products and can be shared with team members and stakeholders</li>
               <li>Develop and iterate on content that meets the needs of our users</li>
-              <li>Collaborate with stakeholders and subject matter experts to define new features and iterate existing capabilities</li>
+              <li>Collaborate with diverse stakeholders and subject matter experts to define new features and iterate existing capabilities</li>
               <li>Serve as a coach and catalyst for leveraging modern data-driven and human-centered design practices across the team and the State in the areas of design research, interaction design, service design, visual design, and information architecture</li>
               <li>Drive user adoption and engagement </li>
+              <li>Take part in office-wide initiatives, such as stand-ups, to enable collaboration and support across projects </li>
             </ul>
             <h6>Preferred Technical Experience, Skills and Abilities</h6>
             <p>Applicants will be assessed based on an ability to excel at one or more product design disciplines: user experience design, user interface design, visual design, and content design.  </p>
             <p>We are seeking individuals with the following experience, skills, and abilities: </p>
             <ul>
               <li>Leading user experience design and research to iteratively develop digital products or services within large or complex environments as part of a cross-functional team</li>
+              <li>Conducting rapid evidence reviews, research, and field scans</li>
               <li>Defining user needs and experience goals using such frameworks as personas, storyboards, scenarios, and flowcharts</li>
               <li>Designing and specifying user interfaces and information architecture, reusing design patterns where relevant</li>
               <li>Developing accessible content</li>
@@ -153,109 +168,7 @@
               <li>Leveraging global web design standards</li>
             </ul>
           </div>
-          <a href="you.html" class="read-more-button">Apply now</a>
-        </div>
-      </div>
-    </div>
 
-    <div class="jobs bio">
-      <div class="jobs">
-        <a class="anchor" id="business-director"></a>
-        <h5>Business Experience Director</h5>
-        <div>
-          <p>The Business Experience Director will be responsible for reimagining and driving the experience of businesses when interacting with the state. You’ll do this by driving the production of constantly-evolving content, similarly getting user feedback regularly through standardized user testing, and acting as stakeholder for new technologies and interfaces through the Business First Stop initiative. The role will thus include elements of content creation, marketing research, user testing, experience design, communications management and product management. You’ll be empowered by being positioned outside of the standard agency structure, avoiding the trap of “shipping an org chart” instead of a cohesive experience.</p>
-          <button class="accordion"><i class="material-icons down"></i></button>
-          <div class="panel">
-            <p>As a part of the team, you will:</p>
-            <ul>
-              <li>Expand Business.NJ.gov content and content delivery as “Editor-in-Chief”:</li>
-              <ul>
-                <li>Develop the ‘start your business’ experience on Business.NJ.gov</li>
-                <li>Develop and run communication with businesses to keep them informed of services, resources, new rules/regs, COVID-updates, etc.</li>
-                <li>Conduct message and content testing sessions on an ongoing basis to ensure content is useable as intended; incorporate feedback/data from website and the Business.NJ.gov chat system to inform content development</li>
-              </ul>
-              <li>Increase business community feedback loops through market research and user testing</li>
-              <ul>
-                <li>Coordinate interviews, surveys, focus groups and stakeholder engagement to bolster feedback mechanisms with small businesses and industry stakeholders and drive strategic development and prioritization of our initiatives</li>
-              </ul>
-              <li>Lead the creation of a new customer service experience for businesses</li>
-              <ul>
-                <li>Coordinate the creation of and manage a cross-departmental customer service operations team to ensure rapid response to business inquiries </li>
-                <li>Coordinate the creation of and manage a cross-departmental customer service advisory council to develop principles and guidelines that must be followed by all agencies and departments when serving businesses</li>
-                <li>Ensure knowledge gained from research and customer service delivery, including business obstacles and burdens, are informing Business.NJ.gov technology and policy decision-making</li>
-              </ul>
-            </ul>
-            <h6>Preferred Technical Experience, Skills and Abilities</h6>
-            <p>Applicants will be assessed based on an ability to excel at content strategy, editing, and product management. </p>
-            <p>We are seeking individuals with the following experience, skills, and abilities: </p>
-            <ul>
-              <li>Writing and developing technical content that is accessible and easily understood for the public</li>
-              <li>Conducting market research and audience analysis</li>
-              <li>Conducting message and content testing</li>
-              <li>Writing, managing, and distributing email and newsletter content, and managing an online newsletter distribution network</li>
-              <li>Managing editorial content and writing assignment with a number of stakeholders and content creators</li>
-              <li>Conducting user interviews and focus groups</li>
-              <li>Crafting and distributing surveys</li>
-              <li>Coordinating stakeholder engagement among multiple stakeholders and oversight departments</li>
-              <li>Establishing customer relationships and customer service standards</li>
-              <li>Incorporating customer feedback and analysis into product design</li>
-              <li>Developing user experience (UX) mockups and prototypes</li>
-              <li>Interpreting web analytics and incorporating into UX prototypes and interface designs</li>
-              <li>Product management and developing product requirements, feature requests, and interface options</li>
-              <li>Developing low-fidelity mockups</li>
-              <li>Using content management systems</li>
-              <li>Technical writing</li>
-              <li>Incorporating global web design assets</li>
-            </ul>
-          </div>
-          <a href="you.html" class="read-more-button">Apply now</a>
-        </div>
-      </div>
-    </div>
-
-    <div class="jobs bio">
-      <div class="jobs">
-        <a class="anchor" id="front-end-engineer"></a>
-        <h5>Front End Engineer</h5>
-        <div>
-          <p>We are seeking a front end software engineer with at least 4 years of experience using modern languages and practices who can translate a concept into initial solutions for users. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy.</p>
-          <button class="accordion"><i class="material-icons down"></i></button>
-          <div class="panel">
-            <p>As a part of the team, you will:</p>
-            <ul>
-              <li>Take problems that may be poorly specified and find the best software solutions, including evaluating custom developed vs. SAAS options</li>
-              <li>Own features end-to-end, from planning to designing and building front-end interfaces</li>
-              <li>Experience applying leading industry development practices to solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
-              <li>Deliver projects with complex requirements, multiple stakeholders with disparate views or high levels of bureaucracy</li>
-              <li>Deliver public-facing products or features on public-facing products with a large number of users (i.e. 100,000+)</li>
-              <li>Deliver tools or products with high uptime or availability requirements (i.e. SLAs of 99.9%+)</li>
-              <li>Work closely with product managers, designers, experts, leadership, and key stakeholders to translate findings and designs into product</li>
-              <li>Iteratively release new product that can be tested with users</li>
-              <li>Coordinate development activities (including the establishment of development processes) and make technical decisions that reflect the ideal solution and practical realities</li>
-              <li>Build and maintain the underlying technical architecture and processes -- including a cloud environment as well as continuous integration, automated testing, and source control processes -- that will enable the team’s success across initiatives</li>
-              <li>Develop technical documentation that can support the completion of state requirements</li>
-              <li>Provide counsel on technical matters in plain English to our team and stakeholders</li>
-              <li>Solve challenges using a wide toolkit that includes writing code, building the technical capacity of the team and State, translating user needs into technical decisions, mapping out technical options and architecture, and coaching and presenting to colleagues</li>
-              <li>Coordinate and work with in-house department and agency technical teams, including those who support legacy systems, to execute on development projects</li>
-            </ul>
-            <h6>Preferred Experience, Skills and Abilities</h6>
-            <p>Applicants will be assessed based on an ability to excel as a front-end engineer.</p>
-            <p>We are seeking individuals with the following experience, skills, and abilities: </p>
-            <ul>
-              <li>Ability to engage with technologies such as: modern JavaScript (strong) in a “Jamstack” architecture, React, Next.js, Cascading Style Sheets (CSS), Hyper Text Markup Language (HTML), JavaScript libraries, linting, and Git/GitHub version control.</li>
-              <li>Building and applying re-usable front-end design patterns to reduce future development overhead</li>
-              <li>Incorporating global web design assets</li>
-              <li>Translating static mockups and images into working prototypes</li>
-              <li>Ensuring 508 accessibility compliance with the assistance of automated testing tools</li>
-              <li>Writing well-designed, testable, efficient code</li>
-              <li>Ensure seamless integration among front- and backend systems</li>
-              <li>Mitigating common security vulnerabilities (e.g., cross-site scripting)</li>
-              <li>Executing full lifecycle software development</li>
-              <li>Writing developer-friendly documentation (e.g., API documentation, deployment operations)</li>
-              <li>Ensuring system uptime and performance</li>
-              <li>Monitoring and notifying appropriate officials in the case of security and data breaches</li>
-            </ul>
-          </div>
           <a href="you.html" class="read-more-button">Apply now</a>
         </div>
       </div>
@@ -266,19 +179,20 @@
         <a class="anchor" id="full-stack-engineer"></a>
         <h5>Full-Stack / Site Reliability Engineer</h5>
         <div>
-          <p>We are seeking site reliability and full-stack software engineers with at least 5 years of experience using modern languages and practices who can translate a concept into initial solutions for users. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy.</p>
+          <p>We are seeking site reliability and full-stack software engineers with at least 5 years of experience using modern languages and practices who can translate a concept into initial solutions for users. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy. Given the pandemic, we’re looking for self-starters who are skilled at driving projects forward while communicating and collaborating closely with the team at a distance. </p>
           <button class="accordion"><i class="material-icons down"></i></button>
           <div class="panel">
             <p>As a part of the team, you will:</p>
             <ul>
+              <li>Deliver solutions that meet the needs of diverse users across New Jersey</li>
               <li>Operate as a solution architect, taking problems that may be poorly specified and finding the best software solutions, including evaluating custom developed vs. SAAS options</li>
               <li>Own features end-to-end, from planning to structuring data models to designing and building front-end interfaces</li>
-              <li>Experience applying leading industry development practices to solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
+              <li>Apply leading industry development practices to solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
               <li>Lead a team of engineers and/or the engineering process</li>
-              <li>Deliver projects with complex requirements, multiple stakeholders with disparate views or high levels of bureaucracy</li>
+              <li>Deliver projects with complex requirements, multiple stakeholders with disparate views, or high levels of bureaucracy</li>
               <li>Deliver public-facing products or features on public-facing products with a large number of users (i.e. 100,000+)</li>
               <li>Deliver tools or products with high uptime or availability requirements (i.e. SLAs of 99.9%+)</li>
-              <li>Work closely with product managers, designers, experts, leadership, and key stakeholders to translate findings and designs into product</li>
+              <li>Work closely with product managers, designers, experts, leadership, and diverse stakeholders to translate findings and designs into product</li>
               <li>Iteratively release new product that can be tested with users</li>
               <li>Coordinate development activities (including the establishment of development processes) and make technical decisions that reflect the ideal solution and practical realities</li>
               <li>Build and maintain the underlying technical architecture and processes -- including a cloud environment as well as continuous integration, automated testing, and source control processes -- that will enable the team’s success across initiatives</li>
@@ -286,6 +200,7 @@
               <li>Provide counsel on technical matters in plain English to our team and stakeholders</li>
               <li>Solve challenges using a wide toolkit that includes writing code, building the technical capacity of the team and State, translating user needs into technical decisions, mapping out technical options and architecture, and coaching and presenting to colleagues</li>
               <li>Coordinate and work with in-house department and agency technical teams, including those who support legacy systems, to execute on development projects and ensure that they are setup to succeed</li>
+              <li>Take part in office-wide initiatives, such as stand-ups, to enable collaboration and support across projects </li>
             </ul>
             <h6>Preferred Technical Experience, Skills and Abilities</h6>
             <p>Applicants will be assessed based on an ability to excel at one or more software engineering disciplines: front-end engineering, back-end engineering, infrastructure engineering.</p>
@@ -293,13 +208,13 @@
             <ul>
               <li>Working at all levels of the stack </li>
               <li>Ability to engage with technologies such as: modern JavaScript (strong) in a “Jamstack” architecture, React, Next.js, Cascading Style Sheets (CSS), Hyper Text Markup Language (HTML), JavaScript libraries, linting, and best practices, Google Cloud Platform (GCP), “NoSQL” document store persistence, and Git/GitHub version control.</li>
-              <li>Building and applying re-usable front-end design patterns to reduce future development overhead</li>
+              <li>Building and applying reusable front-end design patterns to reduce future development overhead</li>
               <li>Incorporating global web design assets</li>
               <li>Translating static mockups and images into working prototypes</li>
               <li>Ensuring 508 accessibility compliance with the assistance of automated testing tools</li>
               <li>Writing well-designed, testable, efficient code</li>
               <li>Writing automated feature/functional tests for application flows</li>
-              <li>Ensure seamless integration among front- and backend systems</li>
+              <li>Ensuring seamless integration among front- and backend systems</li>
               <li>Mitigating common security vulnerabilities (e.g., cross-site scripting)</li>
               <li>Executing full lifecycle software development</li>
               <li>Consuming application programming interfaces (APIs) to new and legacy internal and external systems, some of which may be undocumented</li>
@@ -317,26 +232,146 @@
       </div>
     </div>
 
+    <div class="jobs bio">
+      <div class="jobs">
+        <a class="anchor" id="front-end-engineer"></a>
+        <h5>Front-End Engineer</h5>
+        <div>
+          <p>We are seeking a front-end software engineer with at least 4 years of experience using modern languages and practices who can translate a concept into initial solutions for users. You should be comfortable working in a startup environment where you think independently and operate with a high degree of autonomy. Given the pandemic, we’re looking for self-starters who are skilled at driving projects forward while communicating and collaborating closely with the team at a distance. </p>
+          <button class="accordion"><i class="material-icons down"></i></button>
+          <div class="panel">
+            <p>As a part of the team, you will:</p>
+            <ul>
+              <li>Deliver solutions that meet the needs of diverse users across New Jersey</li>
+              <li>Take problems that may be poorly specified and find the best software solutions, including evaluating custom developed vs. SAAS options</li>
+              <li>Own features end-to-end, from planning to designing and building front-end interfaces</li>
+              <li>Experience applying leading industry development practices to solve complex problems through the use of human-centered design, open-source development and innovation, data-driven decision making, and agile development practices</li>
+              <li>Deliver projects with complex requirements, multiple stakeholders with disparate views, or high levels of bureaucracy</li>
+              <li>Deliver public-facing products or features on public-facing products with a large number of users (i.e. 100,000+)</li>
+              <li>Deliver tools or products with high uptime or availability requirements (i.e. SLAs of 99.9%+)</li>
+              <li>Work closely with product managers, designers, experts, leadership, and diverse stakeholders to translate findings and designs into product</li>
+              <li>Iteratively release new product that can be tested with users</li>
+              <li>Coordinate development activities (including the establishment of development processes) and make technical decisions that reflect the ideal solution and practical realities</li>
+              <li>Build and maintain the underlying technical architecture and processes -- including a cloud environment as well as continuous integration, automated testing, and source control processes -- that will enable the team’s success across initiatives</li>
+              <li>Develop technical documentation that can support the completion of state requirements</li>
+              <li>Provide counsel on technical matters in plain English to our team and stakeholders</li>
+              <li>Solve challenges using a wide toolkit that includes writing code, building the technical capacity of the team and State, translating user needs into technical decisions, mapping out technical options and architecture, and coaching and presenting to colleagues</li>
+              <li>Coordinate and work with in-house department and agency technical teams, including those who support legacy systems, to execute on development projects</li>
+              <li>Take part in office-wide initiatives, such as stand-ups, to enable collaboration and support across projects </li>
+            </ul>
+            <h6>Preferred Experience, Skills and Abilities</h6>
+            <p>Applicants will be assessed based on an ability to excel as a front-end engineer.</p>
+            <p>We are seeking individuals with the following experience, skills, and abilities: </p>
+            <ul>
+              <li>Ability to engage with technologies such as: modern JavaScript (strong) in a “Jamstack” architecture, React, Next.js, Cascading Style Sheets (CSS), Hyper Text Markup Language (HTML), JavaScript libraries, linting, and Git/GitHub version control.</li>
+              <li>Building and applying reusable front-end design patterns to reduce future development overhead</li>
+              <li>Incorporating global web design assets</li>
+              <li>Translating static mockups and images into working prototypes</li>
+              <li>Ensuring 508 accessibility compliance with the assistance of automated testing tools</li>
+              <li>Writing well-designed, testable, efficient code</li>
+              <li>Ensure seamless integration among front- and backend systems</li>
+              <li>Mitigating common security vulnerabilities (e.g., cross-site scripting)</li>
+              <li>Executing full lifecycle software development</li>
+              <li>Writing developer-friendly documentation (e.g., API documentation, deployment operations)</li>
+              <li>Ensuring system uptime and performance</li>
+              <li>Monitoring and notifying appropriate officials in the case of security and data breaches</li>
+            </ul>
+          </div>
+          <a href="you.html" class="read-more-button">Apply now</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="jobs bio">
+      <div class="jobs">
+        <a class="anchor" id="business-director"></a>
+        <h5>Business Experience Director</h5>
+        <div>
+          <p>The Business Experience Director will be responsible for reimagining and driving the experience of businesses when interacting with the State. You’ll do this by driving the production of constantly-evolving content, getting user feedback regularly through standardized user testing, engaging with a diverse audience, and acting as stakeholder for new technologies and interfaces through the Business First Stop initiative. The role will thus include elements of content creation, marketing research, user testing, experience design, communications management, and product management. You’ll be empowered outside of the standard agency structure, avoiding the trap of “shipping an org chart” and instead delivering a cohesive experience. Given the pandemic, we’re looking for self-starters who are skilled at driving projects forward while communicating and collaborating closely with the team at a distance. </p>
+          <button class="accordion"><i class="material-icons down"></i></button>
+          <div class="panel">
+            <p>As a part of the team, you will:</p>
+            <ul>
+              <li>Deliver solutions that meet the needs of diverse users across New Jersey</li>
+              <li>Expand Business.NJ.gov content and content delivery as “Editor-in-Chief”:</li>
+              <ul>
+                <li>Develop the ‘start your business’ experience on Business.NJ.gov</li>
+                <li>Develop and run communication with businesses to keep them informed of services, resources, new rules/regs, COVID-19 updates, etc.</li>
+                <li>Conduct message and content testing sessions on an ongoing basis to ensure content is usable as intended for a diverse audience; incorporate feedback/data from the website and from the Business.NJ.gov chat system to inform content development</li>
+              </ul>
+              <li>Increase business community feedback loops through market research and user testing</li>
+              <ul>
+                <li>Coordinate interviews, surveys, focus groups, and stakeholder engagement to bolster feedback mechanisms with small businesses and industry stakeholders and drive strategic development and prioritization of our initiatives</li>
+              </ul>
+              <li>Lead the creation of a new customer service experience for businesses</li>
+              <ul>
+                <li>Coordinate the creation of, and manage, a cross-departmental customer service operations team to ensure rapid response to business inquiries </li>
+                <li>Coordinate the creation of, and manage, a cross-departmental customer service advisory council to develop principles and guidelines that must be followed by all agencies and departments when serving businesses</li>
+                <li>Ensure knowledge gained from research and customer service delivery, including business obstacles and burdens, are informing Business.NJ.gov technology and policy decision-making</li>
+              </ul>
+              <li>Take part in office-wide initiatives, such as stand-ups, to enable collaboration and support across projects </li>
+            </ul>
+            <p>Preferred Technical Experience, Skills and Abilities</p>
+            <p>Applicants will be assessed based on an ability to excel at content strategy, editing, and product management. </p>
+            <p>We are seeking individuals with the following experience, skills, and abilities: </p>
+            <ul>
+              <li>Writing and developing technical content that is accessible and easily understood for the public</li>
+              <li>Conducting market research and audience analysis</li>
+              <li>Conducting community outreach</li>
+              <li>Conducting message and content testing</li>
+              <li>Writing, managing, and distributing email and newsletter content, and managing an online newsletter distribution network</li>
+              <li>Managing editorial content and writing assignments with a number of stakeholders and content creators</li>
+              <li>Conducting user interviews and focus groups</li>
+              <li>Crafting and distributing surveys</li>
+              <li>Coordinating stakeholder engagement among multiple stakeholders and oversight departments</li>
+              <li>Establishing customer relationships and customer service standards</li>
+              <li>Incorporating customer feedback and analysis into product design</li>
+              <li>Developing user experience (UX) mockups and prototypes</li>
+              <li>Interpreting web analytics and incorporating into UX prototypes and interface designs</li>
+              <li>Product management and developing product requirements, feature requests, and interface options</li>
+              <li>Developing low-fidelity mockups</li>
+              <li>Using content management systems</li>
+              <li>Technical writing</li>
+              <li>Incorporating global web design assets</li>
+            </ul>
+
+          </div>
+          <a href="you.html" class="read-more-button">Apply now</a>
+        </div>
+      </div>
+    </div>
+
+
+
     <h4>About the Office of Innovation</h4>
-    <p>Founded with the mandate to improve the lives of New Jerseyans by designing and deploying more effective and efficient government services, the Office of Innovation works in partnership with the Governor’s office, State agencies, and outside partners to create innovative policies and technologies that address complex public problems by working differently. We apply data science and public engagement to understand problems, and use the latest digital technologies combined with strategic policies to develop solutions that improve services while also reducing costs for the State and the taxpaying public. </p>
+    <p>The Office of Innovation was founded with the mandate to improve the lives of New Jerseyans by designing and deploying more effective and efficient government services. We operate in partnership with the Governor’s office, State agencies and departments, and outside partners - working differently to create innovative policies and technologies that address complex public problems. We apply data science and public engagement to understand problems, and use the latest digital technologies combined with strategic policies to develop solutions that improve services while also reducing costs for the State and the taxpaying public. </p>
+    <p>Our team is made up of dedicated and energetic individuals with experience in government, business, civic tech, policy, and engagement. We are passionate about transforming the way government operates, and we support State agencies in innovating and improving the lives of all New Jerseyans. We partner with teams throughout the state to design and deploy world-class, innovative, and inclusive policies and digital services that solve pressing public interest challenges. </p>
 
     <h5>Principals we innovate by:</h5>
     <ul>
-      <li>Build with New Jerseyans, putting them at the center of our work</li>
+      <li>Innovate <em>with</em>, rather than <em>for</em>, New Jerseyans - using participatory and data-driven methods to improve people’s lives</li>
+      <li>Define concrete and specific problems that matter to real people</li>
+      <li>Collaborate with public, private and nonprofit sectors to enhance our impact</li>
+      <li>Build with diverse New Jerseyans, putting them at the center of our work</li>
       <li>Solve problems by breaking down silos and forming partnerships - across teams, departments, agencies, levels of government, and with external experts</li>
       <li>Deliver accessible solutions and policies that meet the needs of real people</li>
       <li>Succeed in a highly ambiguous environment with little definition or structure</li>
-      <li>Maintain strong domain expertise while keeping a cross-functional approach Acknowledge and overcome constraints as they arise</li>
+      <li>Maintain strong domain expertise while keeping a cross-functional approach l</li>
       <li>Collaborate with stakeholders in domains beyond technology such as legal, policy, and administrative roles</li>
       <li>Be committed and know how to develop metrics and experiments to test what works</li>
-      <li>Enable the long-term success of our partners throughout the state</li>
     </ul>
 
-    <h4>Notes</h4>
-    <p>The examples of work for this title are for illustrative purposes only. A particular position using this title may not perform all duties listed in this job description. Conversely, all duties performed on the job may not be listed. This job description is intended to convey information essential to understanding the scope, general nature and level of work performed by job holders within this job. This job description is not intended to be an exhaustive list of qualifications, skills, efforts, duties, responsibilities or working conditions associated with the position.</p>
-    <p>Your employment is voluntary and subject to termination at will, with or without cause, or with or without notice, at any time. Nothing in this job description shall be interpreted to conflict, eliminate or modify the employment-at-will status of employees.</p>
-    <p>This position is considered exempt and is excluded from minimum wage, overtime regulations, and other rights and protections afforded nonexempt workers under FLSA.</p>
-    <p>We reserve the right to amend/revise this job description as necessary to meet current and changing business needs.</p>
+    <h5>Since our creation, we have engaged on a wide variety of issues, including:</h5>
+    <ul>
+      <li>Responding to emerging and urgent needs, such as the COVID-19 pandemic, by deploying modern digital services and expanding the use and availability of data</li>
+      <li>Improving the delivery of benefits and services, including Unemployment Insurance and SNAP</li>
+      <li>Creating tools to enable the public to participate in open policy making</li>
+      <li>Making modern career services and digital tools available to support job seekers in identifying, preparing for, and obtaining family-sustaining jobs</li>
+      <li>Improving the way entrepreneurs and business owners start, operate, and grow their businesses in the state</li>
+      <li>Exploring policy innovations on issue areas such as economic development, technology governance, open data, open governance, autonomous vehicles, broadband, workforce development and more</li>
+    </ul>
+    <p>You can learn more about us at <a href="https://innovation.nj.gov">innovation.nj.gov.</a></p>
+    <p>We believe this mission can only be fulfilled with a diverse and inclusive team, environment, and approach. Are you interested in joining us?</p>
 
     <h4>The New Jersey Office of Innovation is proud to be an equal opportunity employer</h4>
     <p>We are deeply committed to the principles of equity, diversity, and inclusiveness and seek to create a pluralistic community for all.</p>
@@ -344,8 +379,8 @@
     <p>We do not discriminate against any candidate because of color, race, age, religion, sex, gender identity or expression, sexual orientation, membership in an employee organization, pregnancy, marital status, status as a parent, ancestry, national origin, disability (physical or mental), family medical history or genetic information, political affiliation, military service, retaliation, or other non-merit based factors.</p>
 
     <h4>Eligibility</h4>
-    <p>You must be authorized to work in the United States. Candidates may be required to pass a background check and complete additional steps as part of the application and onboarding process.</p>
-    <p><br></p>
+    <p>You must be authorized to work in the United States. Candidates may be required to pass a background check and complete additional steps as part of the application and onboarding process. You will be considered an “at-will” employee, meaning both employer and employee have the right to terminate employment with or without cause or notice.   </p>
+    <div class="mb-5"></div>
   </div>
 
   <footer class="thin-footer">


### PR DESCRIPTION
@gamorgana Ready to publish. Adds new job descriptions. Jobs link to the embedded Airtable form for applications. Each section is anchor-linkable to make it easier to share individual roles.

Includes some style adjustments to clean up the page for this amount of content.

<details>
<summary>Page preview (one roles expanded as an example)</summary>
<img src="https://user-images.githubusercontent.com/170641/97880746-8b9cc280-1cef-11eb-9eb1-bbb0a5a4ca13.png">

</details>